### PR TITLE
Update pages/index.vue - Patch Error in getGasFee function caused by incorrect headers

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -343,9 +343,9 @@ export default Vue.extend({
             try {
                 const response = await fetch(this.params.getGasUrl, {
                     method: 'GET',
-                    headers: {
-                        'Cache-Control': 'no-store, max-age=0'
-                    }
+                    // headers: {
+                    //     'Cache-Control': 'no-store, max-age=0'
+                    // }
                 });
 
                 if (!response.ok) {


### PR DESCRIPTION
- Remove Cache-Control header from fetch in getGasFee function
- This will solve the problem of cors policy for BSC chain